### PR TITLE
Feat(Queries): Add various queries

### DIFF
--- a/queries/folds.scm
+++ b/queries/folds.scm
@@ -1,0 +1,18 @@
+[
+  (workspace_declaration)
+  (model_declaration)
+  (group_declaration)
+  (person_declaration)
+  (software_system_declaration)
+  (container_declaration)
+  (component_declaration)
+  (configuration_declaration)
+  (views_declaration)
+  (system_context_view_declaration)
+  (container_view_declaration)
+  (dynamic_view_declaration)
+  (styles_declaration)
+  (element_declaration)
+  (relationship_declaration)
+] @fold
+

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -1,0 +1,204 @@
+;; --------------------
+;; Comments & literals
+;; --------------------
+
+(comment) @comment
+
+(number) @number
+(string) @string
+
+(class_value) @type
+(path_value) @string.special
+(url_value) @string.special
+(color) @constant
+
+(wildcard_identifier) @constant.builtin
+
+;; -------------
+;; Punctuation
+;; -------------
+
+[
+  "{"
+  "}"
+] @punctuation.bracket
+
+[
+  "="
+  "->"
+] @operator
+
+;; -------------
+;; Keywords
+;; -------------
+[
+  "workspace"
+  "!identifiers"
+  "name"
+  "description"
+  "!docs"
+  "!adrs"
+  "model"
+  "group"
+  "person"
+  "softwaresystem"
+  "container"
+  "component"
+  "configuration"
+  "scope"
+  "views"
+  "systemcontext"
+  "dynamic"
+  "include"
+  "exclude"
+  "autolayout"
+  "default"
+  "styles"
+  "theme"
+  "themes"
+  "element"
+  "relationship"
+  "tag"
+  "tags"
+  "url"
+] @keyword
+
+; autolayout directions
+[
+  "lr"
+  "rl"
+  "tb"
+  "bt"
+] @keyword
+
+;; --------------------
+;; Identifiers / names
+;; --------------------
+
+; Generic identifiers = variables / symbols
+(identifier) @variable
+
+; Accessor (i.e. object.property)
+(dotted_identifier
+  (identifier) @type)
+
+; Variables defined in the model
+(variable_declaration
+  name: (identifier) @variable)
+
+; Relation endpoints
+(relation_statement
+  source: (relation_identifier) @type
+  target: (relation_identifier) @type
+  relation: (string) @string.special)
+
+; Element & relationship styles – property keys
+(element_property
+  key: (identifier) @property)
+
+; Tags
+(tag_declaration
+  (string) @constant)
+
+(tags_declaration
+  (string) @constant)
+
+; Theme names / paths
+(theme_value
+  (string) @string.special)
+
+;; --------------------
+;; High-level constructs
+;; --------------------
+
+(workspace_declaration
+  "workspace" @keyword
+  (string) @string)
+
+(model_declaration
+  "model" @keyword)
+
+(configuration_declaration
+  "configuration" @keyword)
+
+(views_declaration
+  "views" @keyword)
+
+(styles_declaration
+  "styles" @keyword)
+
+(system_context_view_declaration
+  "systemcontext" @keyword
+  context: (identifier) @type)
+
+(container_view_declaration
+  "container" @keyword
+  context: (identifier) @type)
+
+(dynamic_view_declaration
+  "dynamic" @keyword
+  scope: (_) @type)
+
+(group_declaration
+  "group" @keyword
+  name: (string) @string)
+
+(person_declaration
+  "person" @keyword
+  name: (string) @string)
+
+(software_system_declaration
+  "softwaresystem" @keyword
+  name: (string) @string)
+
+(container_declaration
+  "container" @keyword
+  name: (string) @string)
+
+(component_declaration
+  "component" @keyword
+  name: (string) @string)
+
+;; --------------------
+;; View-level statements
+;; --------------------
+
+(include_statement
+  "include" @keyword
+  [
+    (identifier)
+    (dotted_identifier)
+    (wildcard_identifier)
+  ] @variable)
+
+(exclude_statement
+  "exclude" @keyword
+  [
+    (identifier)
+    (dotted_identifier)
+  ] @variable)
+
+(autolayout_statement
+  "autolayout" @keyword
+  (autolayout_value) @keyword
+  (number)? @number
+  (number)? @number)
+
+(default_statement
+  "default" @keyword)
+
+(description_statement
+  "description" @keyword
+  (string) @string)
+
+(url_declaration
+  "url" @keyword
+  (url_value) @string.special)
+
+(docs_statement
+  "!docs" @keyword
+  (path_value) @string.special)
+
+(adrs_statement
+  "!adrs" @keyword
+  (path_value) @string.special)

--- a/queries/indents.scm
+++ b/queries/indents.scm
@@ -1,0 +1,26 @@
+; Nodes that introduce a `{ ... }` block:
+[
+  (workspace_declaration)
+  (model_declaration)
+  (group_declaration)
+  (person_declaration)
+  (software_system_declaration)
+  (container_declaration)
+  (component_declaration)
+  (configuration_declaration)
+  (views_declaration)
+  (system_context_view_declaration)
+  (container_view_declaration)
+  (dynamic_view_declaration)
+  (styles_declaration)
+  (element_declaration)
+  (relationship_declaration)
+] @indent.begin
+
+; Closing braces finish a block and dedent
+["}"] @indent.end
+["}"] @indent.branch
+
+; Don’t get fancy inside comments/strings
+(comment) @indent.auto
+(string) @indent.auto


### PR DESCRIPTION
Motivation: Grammar is good, but there are no queries, so for example highlighting didn't work in my neovim.

Added the following queries:
- highlights.scm
- folds.scm
- indents.scm

Screenshot shows working highlighting, folds (see styles block), and indentation because of this change:
<img width="431" height="866" alt="Screenshot 2025-12-10 at 12 24 44" src="https://github.com/user-attachments/assets/cdc52771-a572-4e18-a159-4f0cf2d23a22" />

